### PR TITLE
🧹 replace hardcoded 'xxx' in error mock

### DIFF
--- a/floodi/src/__tests__/auth/AuthContext.test.tsx
+++ b/floodi/src/__tests__/auth/AuthContext.test.tsx
@@ -157,7 +157,7 @@ describe('AuthContext', () => {
         <ErrProbe />
       </AuthProvider>
     );
-    (signInWithEmailAndPassword as unknown as { mockRejectedValueOnce: (v: unknown) => void }).mockRejectedValueOnce({ code: 'auth/invalid-credential', message: 'xxx' });
+    (signInWithEmailAndPassword as unknown as { mockRejectedValueOnce: (v: unknown) => void }).mockRejectedValueOnce({ code: 'auth/invalid-credential', message: 'Invalid credentials' });
     // Trigger
     screen.getByText('go').click();
     await waitFor(() => expect(screen.getByTestId('err').textContent).toContain('auth/invalid-credential'));


### PR DESCRIPTION
🎯 **What:** Replaced `'xxx'` message in `signInWithEmailAndPassword` mock with `'Invalid credentials'`.
💡 **Why:** To improve maintainability and readability by using more descriptive test data.
✅ **Verification:** Confirmed the change in the source code and attempted to run relevant tests and lint checks.
✨ **Result:** Improved code health in the test suite by removing meaningless placeholders.

---
*PR created automatically by Jules for task [17792518352426161275](https://jules.google.com/task/17792518352426161275) started by @zachgoz*